### PR TITLE
Added vsz alias to size

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  [Documentation]
+  - Fixed typo in POD markup.
+
+  [Enhancements]
+  - Added vsz as alias for size. (vss is actually a typo.)
+
+  - Used proper aliases instead of wrapper methods.
 
 0.0201    2015-01-05 18:19:39+00:00 Europe/London
   [Other Changes]

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -81,7 +81,7 @@ sub _build_statm {
 
 =head2 C<size>
 
-=head2 c<vss>
+=head2 C<vsz>
 
 Total program size, in pages.
 
@@ -132,13 +132,10 @@ foreach my $attr (keys %stats) {
         );
     }
 
-sub vss {
-    shift->size(@_);
-    }
 
-sub rss {
-    shift->resident(@_);
-    }
+*vss = \&size;
+*vsz = \&size;
+*rss = \&resident;
 
 =for readme continue
 

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -22,6 +22,7 @@ foreach my $key (keys %stats) {
     }
 
 is $stat->vss, $stat->size, 'vss';
+is $stat->vsz, $stat->size, 'vsz';
 is $stat->rss, $stat->resident, 'rss';
 
 done_testing;


### PR DESCRIPTION
Added vsz alias to size (vss was a typo, but left it there for
backwards compatability).

Changed aliases to proper aliases from wrapper subs.

Fixed typo in POD markup.
