### PR TITLE
Various changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,7 +6,7 @@ Revision history for Linux-Statm-Tiny
 
   [Enhancements]
   - vsz and rss and *_pages attributes are explicitly defined as
-    alias.
+    aliases.
 
   - dist.ini modified to use AutoPrereqs and add better
     metadata to the distribution.

--- a/Changes
+++ b/Changes
@@ -16,6 +16,8 @@ Revision history for Linux-Statm-Tiny
 
   - The kb and mb aliases use the ceil function to round values up.
 
+  - Added refresh method to refresh values.
+
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]
   - Fixed typo in POD markup.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Linux-Statm-Tiny
 
+{{$NEXT}}
+  [Enhancements]
+  - vsz and rss and explicitly defined as aliases
+
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]
   - Fixed typo in POD markup.

--- a/Changes
+++ b/Changes
@@ -5,7 +5,8 @@ Revision history for Linux-Statm-Tiny
   - Improved POD so that it's clear that vsz and rss are aliases.
 
   [Enhancements]
-  - vsz and rss and explicitly defined as aliases
+  - vsz and rss and *_pages attributes are explicitly defined as
+    alias.
 
   - dist.ini modified to use AutoPrereqs and add better
     metadata to the distribution.
@@ -17,6 +18,9 @@ Revision history for Linux-Statm-Tiny
   - The kb and mb aliases use the ceil function to round values up.
 
   - Added refresh method to refresh values.
+
+  [Other Changes]
+  - Added tests for pages alias.
 
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]

--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for Linux-Statm-Tiny
   [Enhancements]
   - vsz and rss and explicitly defined as aliases
 
+  - dist.ini modified to use AutoPrereqs and add better
+    metadata to the distribution.
+
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]
   - Fixed typo in POD markup.

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Linux-Statm-Tiny
 
 {{$NEXT}}
+  [Documentation]
+  - Improved POD so that it's clear that vsz and rss are aliases.
+
   [Enhancements]
   - vsz and rss and explicitly defined as aliases
 

--- a/Changes
+++ b/Changes
@@ -12,6 +12,10 @@ Revision history for Linux-Statm-Tiny
 
   - Removed use of common::sense in the tests.
 
+  - Added mb aliases, e.g. "size_mb".
+
+  - The kb and mb aliases use the ceil function to round values up.
+
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]
   - Fixed typo in POD markup.

--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ Revision history for Linux-Statm-Tiny
   - dist.ini modified to use AutoPrereqs and add better
     metadata to the distribution.
 
+  - Removed use of common::sense in the tests.
+
 0.0300    2015-01-12 11:26:08+00:00 Europe/London
   [Documentation]
   - Fixed typo in POD markup.

--- a/README.pod
+++ b/README.pod
@@ -4,7 +4,7 @@ Linux::Statm::Tiny - simple access to Linux /proc/../statm
 
 =head1 VERSION
 
-0.0300
+0.0400
 
 =head1 SYNOPSIS
 
@@ -21,13 +21,17 @@ L<How to install CPAN modules|http://www.cpan.org/modules/INSTALL.html>.
 
 =head2 Required Modules
 
-This distribution requires Perl v5.8.0.
+This distribution requires Perl v5.8.8.
 
 This distribution requires the following modules:
 
 =over 4
 
 =item * L<Moo>
+
+=item * L<MooX::Aliases>
+
+=item * L<namespace::sweep>
 
 =item * L<Types::Standard>
 
@@ -41,11 +45,7 @@ This distribution requires the following modules:
 
 =item * 
 
-Fixed typo in POD markup.
-
-=item * 
-
-Bumped copyright year.
+Improved POD so that it's clear that vsz and rss are aliases.
 
 =back
 
@@ -55,33 +55,37 @@ Bumped copyright year.
 
 =item * 
 
-Added vsz as alias for size.
+vsz and rss and *_pages attributes are explicitly defined as alias.
 
 =item * 
 
-Used proper aliases instead of wrapper methods.
+dist.ini modified to use AutoPrereqs and add better metadata to the distribution.
 
 =item * 
 
-Added *_pages aliases.
+Removed use of common::sense in the tests.
 
 =item * 
 
-Aded page_size attribute.
+Added mb aliases, e.g. "size_mb".
 
 =item * 
 
-Added *_bytes and *_kb methods.
+The kb and mb aliases use the ceil function to round values up.
+
+=item * 
+
+Added refresh method to refresh values.
 
 =back
 
-=head2 Incompatabile Changes
+=head2 Other Changes
 
 =over 4
 
 =item * 
 
-Removed vss alias, which is a typo. Use vsz.
+Added tests for pages alias.
 
 =back
 

--- a/dist.ini
+++ b/dist.ini
@@ -9,18 +9,9 @@ copyright_year   = 2015
 
 [@Basic]
 
-[Prereqs]
-perl            = 5.008
-Fcntl           = 0
-Moo             = 0
-Types::Standard = 0
-
-[Prereqs / Test]
--phase = test
-
-Test::More      = 0
-
+[AutoPrereqs]
 [RecommendedPrereqs]
+[PrereqsClean]
 
 [GitHub::Meta]
 repo = git://github.com/robrwo/Linux-Statm-Tiny.git
@@ -32,6 +23,7 @@ type = pod
 copy = Changes
 
 [ManifestSkip]
+[MetaJSON]
 
 [NextRelease]
 

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -166,14 +166,11 @@ foreach my $attr (keys %stats) {
         isa      => Int,
         default  => sub { shift->statm->[$stats{$attr}] },
         init_arg => undef,
-        alias    => $aliases{$attr},
+        alias    => [ grep { defined $_ } $aliases{$attr}, "${attr}_pages" ],
         clearer  => "_refresh_${attr}",
         );
 
     push @attrs, $attr;
-
-    no strict 'refs';
-    *{$attr . '_pages'} = \&{$attr};
 
     foreach my $alt (keys %alts) {
         has "${attr}_${alt}" => (

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -1,6 +1,7 @@
 package Linux::Statm::Tiny;
 
 use Moo;
+use MooX::Aliases;
 
 use Fcntl qw/ O_RDONLY /;
 use Types::Standard qw/ ArrayRef Int /;
@@ -138,8 +139,11 @@ my %stats = (
     lib      => 4,
     data     => 5,
     dt       => 6,
-    vsz      => 0, # alias
-    rss      => 1, # alias
+    );
+
+my %aliases = (
+    size     => 'vsz',
+    resident => 'rss',
     );
 
 my %alts = (       # page_size multipliers
@@ -153,6 +157,7 @@ foreach my $attr (keys %stats) {
         isa      => Int,
         default  => sub { shift->statm->[$stats{$attr}] },
         init_arg => undef,
+        alias    => $aliases{$attr},
         );
 
     no strict 'refs';

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -7,7 +7,7 @@ use Fcntl qw/ O_RDONLY /;
 use Types::Standard qw/ ArrayRef Int /;
 
 {
-    $Linux::Statm::Tiny::VERSION = '0.0300'
+    $Linux::Statm::Tiny::VERSION = '0.0400'
 }
 
 =head1 NAME

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -99,15 +99,19 @@ sub _build_statm {
 
 =head2 C<size>
 
+Total program size, in pages.
+
 =head2 C<vsz>
 
-Total program size, in pages.
+An alias for L</size>.
 
 =head2 C<resident>
 
+Resident set size (RSS), in pages.
+
 =head2 C<rss>
 
-Resident set size (RSS), in pages.
+An alias for L</resident>.
 
 =head2 C<share>
 

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -174,7 +174,7 @@ foreach my $attr (keys %stats) {
             is       => 'lazy',
             isa      => Int,
             default  => sub { my $self = shift;
-                              ceil($self->statm->[$stats{$attr}] * $self->page_size / $alts{$alt});
+                              ceil($self->$attr * $self->page_size / $alts{$alt});
                               },
             init_arg => undef,
             );

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -4,6 +4,7 @@ use Moo;
 use MooX::Aliases;
 
 use Fcntl qw/ O_RDONLY /;
+use POSIX qw/ ceil /;
 use Types::Standard qw/ ArrayRef Int /;
 
 {
@@ -153,6 +154,7 @@ my %aliases = (
 my %alts = (       # page_size multipliers
     bytes    => 1,
     kb       => 1024,
+    mb       => 1048576,
     );
 
 foreach my $attr (keys %stats) {
@@ -172,7 +174,7 @@ foreach my $attr (keys %stats) {
             is       => 'lazy',
             isa      => Int,
             default  => sub { my $self = shift;
-                              $self->statm->[$stats{$attr}] * $self->page_size / $alts{$alt};
+                              ceil($self->statm->[$stats{$attr}] * $self->page_size / $alts{$alt});
                               },
             init_arg => undef,
             );
@@ -185,8 +187,12 @@ foreach my $attr (keys %stats) {
 You can append the "_pages" suffix to attributes to make it explicit
 that the return value is in pages, e.g. C<vsz_pages>.
 
-You can also use the "_bytes" or "_kb" suffixes to get the values in bytes
-or kilobytes, e.g. C<vsz_bytes> and C<vsz_kb>.
+You can also use the "_bytes", "_kb" or "_mb" suffixes to get the
+values in bytes, kilobytes or megabytes, e.g. C<size_bytes>, C<size_kb>
+and C<size_mb>.
+
+The fractional kilobyte and megabyte sizes will be rounded up, e.g.
+if the L</size> is 1.04 MB, then C<size_mb> will return "2".
 
 =for readme continue
 

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More;
 
+use POSIX qw/ ceil /;
+
 use_ok 'Linux::Statm::Tiny';
 
 ok my $stat = Linux::Statm::Tiny->new(), 'new';
@@ -23,6 +25,7 @@ my %mults = (
     pages    => 1,
     bytes    => $stat->page_size,
     kb       => $stat->page_size / 1024,
+    mb       => $stat->page_size / (1024 * 1024),
     );
 
 note( explain $stat->statm );
@@ -35,7 +38,7 @@ foreach my $key (keys %stats) {
     foreach my $type (keys %mults) {
         my $name = "${key}_${type}";
         ok my $method = $stat->can($name), "can ${name}";
-        is $stat->$method, $stat->$key * $mults{$type}, $name;
+        is $stat->$method, ceil($stat->$key * $mults{$type}), $name;
         }
 
     }

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -46,6 +46,9 @@ sub test_stats {
         note "${key} = " . $stat->$key;
         is $stat->$key, $stat->statm->[$stats{$key}], $key;
 
+        my $alt = "${key}_pages";
+        is $stat->$alt, $stat->$key, $alt;
+
         foreach my $type (keys %mults) {
             my $name = "${key}_${type}";
             ok my $method = $stat->can($name), "can ${name}";

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -1,5 +1,7 @@
+use strict;
+use warnings;
+
 use Test::More;
-use common::sense;
 
 use_ok 'Linux::Statm::Tiny';
 


### PR DESCRIPTION
- Improved POD so that it's clear that vsz and rss are aliases.
- vsz and rss and *_pages attributes are explicitly defined as
  aliases using MooX::Aliases.
- dist.ini modified to use AutoPrereqs and add better
  metadata to the distribution.
- Removed use of common::sense in the tests.
- Added mb aliases, e.g. "size_mb".
- The kb and mb aliases use the ceil function to round values up.
- Added refresh method to refresh values.
- Added tests for pages alias.
