### PR TITLE
Fix pid detection in forks

### DIFF
--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -56,7 +56,7 @@ C<$$>.
 has pid => (
     is      => 'lazy',
     isa     => Int,
-    default => $$,
+    default => sub { $$ },
     );
 
 =head2 C<page_size>

--- a/t/20-fork.t
+++ b/t/20-fork.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+plan skip_all => "Not a Linux machine" if $^O ne 'linux';
+
+use_ok 'Linux::Statm::Tiny';
+
+ok my $stat = Linux::Statm::Tiny->new(), 'new';
+
+my ($pread, $pwrite);
+pipe($pread, $pwrite);
+
+my $pid = fork();
+die "fork failed" unless defined $pid;
+
+if ($pid == 0) {
+    my $check = ($$ == $stat->pid);
+    print $pwrite "$check\n";
+    exit;
+}
+
+waitpid($pid, 0);
+my $t = <$pread>;
+chomp($t);
+ok $t, 'got the right pid in a fork';
+
+done_testing();


### PR DESCRIPTION
We must use a coderef for the default of the pid attribute, or
it will only reference the pid of the perl process that first loaded
it.

This means that if we fork(), we'd get stats for the parent process
rather than the process that we're in.