### PR TITLE
Sse Pod::Weaver and update the documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ Revision history for Linux-Statm-Tiny
 
   - Reorganised POD.
 
+  - Updated POD with a reference to the security policy.
+
 0.0701    2025-03-31 14:51:49+01:00 Europe/London
   [Security]
   - Rebuilt with Mite 0.013000 to fix CVE-2025-3051. (See also CVE-2025-30672.)

--- a/Changes
+++ b/Changes
@@ -6,6 +6,8 @@ Revision history for Linux-Statm-Tiny
 
   - Update the copyright year.
 
+  - Reorganised POD.
+
 0.0701    2025-03-31 14:51:49+01:00 Europe/London
   [Security]
   - Rebuilt with Mite 0.013000 to fix CVE-2025-3051. (See also CVE-2025-30672.)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ When submitting a bug or request, please include a test-file or a
 patch to an existing test-file that illustrates the bug or desired
 feature.
 
+## Reporting Security Vulnerabilities
+
+Security issues should not be reported on the bugtracker website. Please see `SECURITY.md` for instructions how to
+report security vulnerabilities
+
 # AUTHOR
 
 Robert Rothenberg <rrwo@cpan.org>

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ report security vulnerabilities
 
 Robert Rothenberg <rrwo@cpan.org>
 
+The current maintainer is James Raspass <jraspass@gmail.com>.
+
 # CONTRIBUTORS
 
 - Adrian Lai <aidy@cpan.org>

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Data + Stack.
 
 Dirty pages (unused in Linux 2.6).
 
-# ALIASES
+## Suffixes
 
 You can append the "\_pages" suffix to attributes to make it explicit
 that the return value is in pages, e.g. `vsz_pages`.

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -26,9 +26,7 @@ This class returns the Linux memory stats from F</proc/$pid/statm>.
 
 =for readme stop
 
-=head1 ATTRIBUTES
-
-=head2 C<pid>
+=attr C<pid>
 
 The PID to obtain stats for. If omitted, it uses the current PID from
 C<$$>.
@@ -41,11 +39,11 @@ has pid => (
     default => sub { $$ },
     );
 
-=head2 C<page_size>
+=attr C<page_size>
 
 The page size.
 
-=head2 C<statm>
+=attr C<statm>
 
 The raw array reference of values.
 
@@ -68,41 +66,53 @@ sub _build_statm {
     [ split / /, $raw ];
     }
 
-=head2 C<size>
+=attr C<size>
 
 Total program size, in pages.
 
-=head2 C<vsz>
+=attr C<vsz>
 
 An alias for L</size>.
 
-=head2 C<resident>
+=attr C<resident>
 
 Resident set size (RSS), in pages.
 
-=head2 C<rss>
+=attr C<rss>
 
 An alias for L</resident>.
 
-=head2 C<share>
+=attr C<share>
 
 Shared pages.
 
-=head2 C<text>
+=attr C<text>
 
 Text (code).
 
-=head2 C<lib>
+=attr C<lib>
 
 Library (unused in Linux 2.6).
 
-=head2 C<data>
+=attr C<data>
 
 Data + Stack.
 
-=head2 C<dt>
+=attr C<dt>
 
 Dirty pages (unused in Linux 2.6).
+
+=attr Suffixes
+
+You can append the "_pages" suffix to attributes to make it explicit
+that the return value is in pages, e.g. C<vsz_pages>.
+
+You can also use the "_bytes", "_kb" or "_mb" suffixes to get the
+values in bytes, kilobytes or megabytes, e.g. C<size_bytes>, C<size_kb>
+and C<size_mb>.
+
+The fractional kilobyte and megabyte sizes will be rounded up, e.g.
+if the L</size> is 1.04 MB, then C<size_mb> will return "2".
 
 =cut
 
@@ -163,6 +173,16 @@ foreach my $attr (keys %stats) {
 
     }
 
+=method C<refresh>
+
+The values do not change dynamically. If you need to refresh the
+values, then you you must either create a new instance of the object,
+or use the C<refresh> method:
+
+  $stats->refresh;
+
+=cut
+
 around refresh => sub {
     my ($next, $self) = @_;
     $self->$next( $self->_build_statm );
@@ -171,29 +191,6 @@ around refresh => sub {
         $self->$meth;
         }
     };
-
-
-=head1 ALIASES
-
-You can append the "_pages" suffix to attributes to make it explicit
-that the return value is in pages, e.g. C<vsz_pages>.
-
-You can also use the "_bytes", "_kb" or "_mb" suffixes to get the
-values in bytes, kilobytes or megabytes, e.g. C<size_bytes>, C<size_kb>
-and C<size_mb>.
-
-The fractional kilobyte and megabyte sizes will be rounded up, e.g.
-if the L</size> is 1.04 MB, then C<size_mb> will return "2".
-
-=head1 METHODS
-
-=head2 C<refresh>
-
-The values do not change dynamically. If you need to refresh the
-values, then you you must either create a new instance of the object,
-or use the C<refresh> method:
-
-  $stats->refresh;
 
 =head1 SEE ALSO
 

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -196,6 +196,13 @@ around refresh => sub {
 
 L<proc(5)>.
 
+=head1 append:BUGS
+
+=head2 Reporting Security Vulnerabilities
+
+Security issues should not be reported on the bugtracker website. Please see F<SECURITY.md> for instructions how to
+report security vulnerabilities
+
 =cut
 
 1;

--- a/lib/Linux/Statm/Tiny.pm
+++ b/lib/Linux/Statm/Tiny.pm
@@ -196,6 +196,10 @@ around refresh => sub {
 
 L<proc(5)>.
 
+=head1 append:AUTHOR
+
+The current maintainer is James Raspass <jraspass@gmail.com>.
+
 =head1 append:BUGS
 
 =head2 Reporting Security Vulnerabilities

--- a/weaver.ini
+++ b/weaver.ini
@@ -13,6 +13,9 @@
 [Generic / SYNOPSIS]
 [Generic / DESCRIPTION]
 
+[Collect / ATTRIBUTES]
+command = attr
+
 [Collect / METHODS]
 command = method
 


### PR DESCRIPTION
This change
- Reorganises the POD using Pod::Weaver commands to collect the attributes and methods
- Adds a mention of the security policy
- Explicitly mentions @JRaspass as the current maintainer
